### PR TITLE
Add parens around print statement

### DIFF
--- a/midiutil/MidiFile.py
+++ b/midiutil/MidiFile.py
@@ -377,7 +377,7 @@ class MIDITrack:
                 self.MIDIEventList.append(event)
 
             else:
-                print "Error in MIDITrack: Unknown event type"
+                print("Error in MIDITrack: Unknown event type")
                 sys.exit(2)
             
         # Assumptions in the code expect the list to be time-sorted.


### PR DESCRIPTION
Hi,

Without these parens I get the following error:

![image](https://github.com/user-attachments/assets/f6188344-766d-4c77-981c-cb023e42c507)

WDYT